### PR TITLE
Add method to clear the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Promise Throttle &nbsp; [![Build Status](https://api.travis-ci.org/JMPerez/promise-throttle.svg)](https://travis-ci.org/JMPerez/promise-throttle/) [![Coverage Status](https://coveralls.io/repos/github/JMPerez/promise-throttle/badge.svg?branch=master)](https://coveralls.io/r/JMPerez/promise-throttle?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/JMPerez/promise-throttle.svg)](https://greenkeeper.io/)
 ==================
 
-
 This is a small library to limit the amount of promises run per unit of time. It is useful for scenarios such as Rest APIs consumption, where we are normally rate-limited to a certain amount of requests per time.
 
 It doesn't have any dependencies. If you are running this on Node.js, you will need to pass whatever Promise library you are using in the constructor.
@@ -56,9 +55,17 @@ The library can be used either server-side or in the browser.
 Also you can specify `weight` parameter for each promise to dynamically adjust throttling depending on
 action "heaviness". For example, action with `weight = 2` will be throttled as two regular actions. By default weight of all actions is 1.
 
-```javascript  
+```javascript
   var regularAction = promiseThrottle.add(performRegularCall());
   var heavyAction = promiseThrottle.add(performHeavyCall(), 2);
+```
+
+In some cases it might be useful to clear the queued promises. For instance, if an operation that involves requests to an API gets cancelled:
+
+```javascript
+promiseThrottle.addAll(lotsOfPromises);
+// ...
+promiseThrottle.clear();
 ```
 
 ## Installation

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -219,4 +219,28 @@ describe('PromiseThrottle', function() {
     });
   });
 
+  describe('#clear()', function() {
+    it('should clear the queued promises', function(done) {
+      var pt10 = createPromiseThrottle(1);
+      var resolved = [];
+      var fn1 = function() {
+        resolved.push(1);
+        return Promise.resolve();
+      };
+      var fn2 = function() {
+        resolved.push(2);
+        return Promise.resolve();
+      };
+
+      pt10.addAll([fn1, fn2]);
+      setTimeout(function() {
+        assert.deepEqual([1], resolved);
+        pt10.clear();
+      })
+      setTimeout(function() {
+        assert.deepEqual([1], resolved);
+        done();
+      }, 2000)
+    });
+  });
 });

--- a/lib/main.js
+++ b/lib/main.js
@@ -39,7 +39,7 @@ PromiseThrottle.prototype.add = function(promise, weight) {
  * Adds all the promises passed as parameters
  * @param {Function} promises An array of functions that return a promise
  * @param {number} weight A "weight" of each operation resolving by array of promises
- * @return {void}
+ * @return {Promise} A promise
  */
 PromiseThrottle.prototype.addAll = function(promises, weight) {
   var addedPromises = promises.map(function(promise) {
@@ -69,6 +69,14 @@ PromiseThrottle.prototype.dequeue = function() {
       }.bind(this), inc - elapsed);
     }
   }
+};
+
+/**
+ * Clears queued promises
+ * @return {void}
+ */
+PromiseThrottle.prototype.clear = function() {
+  this.queued = [];
 };
 
 /**


### PR DESCRIPTION
This is a bit of a workaround since it's not possible to abort promises according to the spec. Clearing the queue will prevent queued promises from being executed.