### PR TITLE
Add support to abort queued promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,39 @@ The library can be used either server-side or in the browser.
     });
 ```
 
-Also you can specify `weight` parameter for each promise to dynamically adjust throttling depending on
+### Options
+
+**weight**
+You can specify `weight` option for each promise to dynamically adjust throttling depending on
 action "heaviness". For example, action with `weight = 2` will be throttled as two regular actions. By default weight of all actions is 1.
 
-```javascript  
+```javascript
   var regularAction = promiseThrottle.add(performRegularCall());
-  var heavyAction = promiseThrottle.add(performHeavyCall(), 2);
+  var heavyAction = promiseThrottle.add(performHeavyCall(), {weight: 2});
+```
+
+**signal**
+You can cancel queued promises using [AbortController and AbortSignal](https://developer.mozilla.org/docs/Web/API/AbortController). For this, pass a `signal` option obtained from an `AbortController`. Once it is aborted, the promises queued using the signal will be rejected.
+
+If the environment where you are running the code doesn't support AbortController, you can use [a polyfill](https://github.com/mo/abortcontroller-polyfill).
+
+```js
+var controller = new AbortController();
+var signal = controller.signal;
+var pt = createPromiseThrottle(10);
+pt.addAll([
+  function() {
+    return fetch('example.com/a');
+  },
+  function() {
+    return fetch('example.com/b');
+  },
+  function() {
+    ...
+  }
+], {signal: signal});
+...
+controller.abort();
 ```
 
 ## Installation

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,17 +18,20 @@ function PromiseThrottle(options) {
 /**
  * Adds a promise
  * @param {Function} promise A function returning the promise to be added
- * @param {number} weight A "weight" of operation resolving by this promise
+ * @param {Object} options A set of options.
+ * @param {number} options.weight A "weight" of each operation resolving by array of promises
  * @return {Promise} A promise
  */
-PromiseThrottle.prototype.add = function(promise, weight) {
+PromiseThrottle.prototype.add = function(promise, options) {
   var self = this;
+  var opt = options || {};
   return new self.promiseImplementation(function(resolve, reject) {
     self.queued.push({
       resolve: resolve,
       reject: reject,
       promise: promise,
-      weight: weight || 1,
+      weight: opt.weight || 1,
+      signal: opt.signal
     });
 
     self.dequeue();
@@ -38,12 +41,13 @@ PromiseThrottle.prototype.add = function(promise, weight) {
 /**
  * Adds all the promises passed as parameters
  * @param {Function} promises An array of functions that return a promise
- * @param {number} weight A "weight" of each operation resolving by array of promises
- * @return {void}
+ * @param {Object} options A set of options.
+ * @param {number} options.weight A "weight" of each operation resolving by array of promises
+ * @return {Promise} A promise that succeeds when all the promises passed as options do
  */
-PromiseThrottle.prototype.addAll = function(promises, weight) {
+PromiseThrottle.prototype.addAll = function(promises, options) {
   var addedPromises = promises.map(function(promise) {
-    return this.add(promise, weight || 1);
+    return this.add(promise, options);
   }.bind(this));
 
   return Promise.all(addedPromises);
@@ -79,11 +83,16 @@ PromiseThrottle.prototype.dequeue = function() {
 PromiseThrottle.prototype._execute = function() {
   this.lastStartTime = new Date();
   var candidate = this.queued.shift();
-  candidate.promise().then(function(r) {
-    candidate.resolve(r);
-  }).catch(function(r) {
-    candidate.reject(r);
-  });
+  var aborted = candidate.signal && candidate.signal.aborted;
+  if (aborted) {
+    candidate.reject(new DOMException('', 'AbortError'));
+  } else {
+    candidate.promise().then(function(r) {
+      candidate.resolve(r);
+    }).catch(function(r) {
+      candidate.reject(r);
+    });
+  }
 };
 
 module.exports = PromiseThrottle;


### PR DESCRIPTION
This PR introduces a `signal` option following the standard implemented for cancellable/abortable `fetch()`. See https://developer.mozilla.org/docs/Web/API/AbortController/abort for more information.

The PR aims to solve the same problem as https://github.com/JMPerez/promise-throttle/pull/41 but in a more complying way and with more fine control to abort only selected queued operations.
