### PR TITLE
Add typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+export interface ThrottleOptions {
+  requestsPerSecond: number
+  promiseImplementation?: PromiseConstructorLike
+}
+
+export interface QueueOptions {
+  weight?: number
+  signal?: AbortSignal
+}
+
+export default class PromiseThrottle {
+  constructor(options: ThrottleOptions)
+  add<T>(promise: Promise<T>, opts?: QueueOptions): Promise<T>
+  addAll<T>(promises: Promise<T>[], opts?: QueueOptions): Promise<T[]>
+}


### PR DESCRIPTION
I think this is not entirely correct in the sense that it may not accept Bluebird promises in `add`/`addAll` but I'm not proficient enough in Typescript to handle that.

I could have used `PromiseLike` there but then it's going to lose the actual promise class in return type, which may be undesired (e.g. it will lose `finally` typing when called with native promises).