### PR TITLE
Include index.d.ts in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "throttle"
   ],
   "files": [
-    "lib/main.js"
+    "lib/main.js",
+    "index.d.ts"
   ],
   "devDependencies": {
     "coveralls": "^3.1.0",


### PR DESCRIPTION
The TypeScript declaration file from v1.1.0 is not included in v1.1.0. That's because `lib/main.js` is the only whitelisted file.

Running `npm publish --dry-run` *before* this change:
```
npm notice
npm notice 📦  promise-throttle@1.1.0
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 3.0kB lib/main.js
npm notice 943B  package.json
npm notice 5.1kB README.md
npm notice === Tarball Details ===
npm notice name:          promise-throttle
npm notice version:       1.1.0
npm notice package size:  3.8 kB
npm notice unpacked size: 10.1 kB
npm notice shasum:        4bc78f7b6073d03b044f84c2c49593ace277b355
npm notice integrity:     sha512-iKip8iHg5SAL3[...]Thlr4wFmTL/EA==
npm notice total files:   4
npm notice
+ promise-throttle@1.1.0
```

Running `npm publish --dry-run` *after* this change:
```
npm notice
npm notice 📦  promise-throttle@1.1.0
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 3.0kB lib/main.js
npm notice 961B  package.json
npm notice 5.1kB README.md
npm notice 406B  index.d.ts
npm notice === Tarball Details ===
npm notice name:          promise-throttle
npm notice version:       1.1.0
npm notice package size:  4.0 kB
npm notice unpacked size: 10.5 kB
npm notice shasum:        4cc4648a48ae82e09fcc167097f670c81bb2a8e0
npm notice integrity:     sha512-r7NTueAxIz4MU[...]cQB4h626wMFLA==
npm notice total files:   5
npm notice
+ promise-throttle@1.1.0
```